### PR TITLE
Add a `/stats` endpoint with stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *~
 authors.csv
 *.egg-info
+publications.yml
+authors.yml
+venv

--- a/citation_reporter/LibrarySearcher.py
+++ b/citation_reporter/LibrarySearcher.py
@@ -1,0 +1,23 @@
+import os, sys, re, requests
+from datetime import datetime
+import logging
+
+START_YEAR=2010
+END_YEAR=datetime.now().year
+
+class LibrarySearcher(object):
+  @classmethod
+  def get_pubmed_ids(cls, start_year=START_YEAR, end_year=END_YEAR):
+    pubmed_ids = set()
+    logging.info("Getting pubmed_ids from the Library")
+    try:
+      for year in range(start_year, end_year + 1):
+        r = requests.get("http://www.sanger.ac.uk/research/publications/%s.html" %
+                         year)
+        new_pubmed_ids = re.findall("http://ukpmc.ac.uk/abstract/MED/(\d{8})",
+                                    r.text)
+        pubmed_ids.update(new_pubmed_ids)
+    except Exception as e:
+      logging.error("Could not fetch pubmed_ids from the Library: %s" % e)
+    logging.info("Fetched %s ids from the library" % len(pubmed_ids))
+    return pubmed_ids

--- a/citation_reporter/PubmedSearch.py
+++ b/citation_reporter/PubmedSearch.py
@@ -110,6 +110,10 @@ class Publications(OrderedDict):
     return Publications([publication for publication in self.values() if
             publication.confirmation_status != Publication.DENIED])
 
+  def confirmed(self):
+    return Publications([publication for publication in self.values() if
+            publication.has_confirmed_author()])
+
   def has_potential_author(self):
     publications = Publications()
     for pubmed_id, publication in self.items():

--- a/citation_reporter/templates/publications.html
+++ b/citation_reporter/templates/publications.html
@@ -84,7 +84,9 @@
       <div class="row">
         <div class="col-sm-2" id="sidebar">
           <ul class="nav nav-pills nav-stacked">
+            {% if download_link is defined %}
             <li><a href="{{ download_link }}" class="btn btn-primary btn-block">Download</a></li>
+	    {% endif %}
             <li><a href="/" class="btn btn-default btn-block">All publications</a></li>
             <li><a href="/trash/" class="btn btn-default btn-block">Trash</a></li>
           </ul>

--- a/scripts/citation_reporter_cli.py
+++ b/scripts/citation_reporter_cli.py
@@ -8,12 +8,12 @@ import logging
 import tempfile
 
 from citation_reporter.Author import User
+from citation_reporter.LibrarySearcher import LibrarySearcher
 from citation_reporter.PubmedSearch import Searcher, Publication, Publications
 
 START_YEAR=2010
 END_YEAR=datetime.now().year+1
 DEFAULT_AFFILIATION="Sanger"
-
 
 def main():
   usage = "usage: %prog [options]"
@@ -96,17 +96,9 @@ if __name__=="__main__":
   logging.info("Found %s citations by searching pubmed" % pubmed_id_count)
 
   logging.info("Getting pubmed_ids from the Library")
-  try:
-    for year in range(options.start, options.end + 1):
-      r = requests.get("http://www.sanger.ac.uk/research/publications/%s.html" %
-                       year)
-      new_pubmed_ids = re.findall("http://ukpmc.ac.uk/abstract/MED/(\d{8})",
-                                  r.text)
-      pubmed_ids.update(new_pubmed_ids)
-  except Exception as e:
-    logging.error("Could not fetch pubmed_ids from the Library: %s" % e)
-  logging.info("Fetched another %s ids from the library" % (len(pubmed_ids) -
-               pubmed_id_count))
+  new_pubmed_ids = LibrarySearcher.get_pubmed_ids(options.start, options.end)
+  pubmed_ids.update(new_pubmed_ids)
+  logging.info("Found additional %s publications in Library" % (len(pubmed_ids) - pubmed_id_count))
 
   new_publications = Publications.from_pubmed_ids(list(pubmed_ids))
   publications = Publications.merge(publications, new_publications)


### PR DESCRIPTION
I've added a `/stats` endpoint so that I can quickly review how many publications need confirmation and how many are not in the Sanger Library records.

This endpoint isn't something that I'd want users to use so I've not publicised it on any page.

As part of adding this feature I've split out the functionality to search the Library.