### PR TITLE
Compare current UTC and file UTC not local and UTC

### DIFF
--- a/sanger_deployment/checks/check_citation_reporter_web_backups.py
+++ b/sanger_deployment/checks/check_citation_reporter_web_backups.py
@@ -7,7 +7,7 @@ import datetime
 
 from collections import OrderedDict
 
-now = datetime.datetime.now()
+now = datetime.datetime.utcnow()
 
 def delta_seconds(filepath):
   atime = datetime.datetime.utcfromtimestamp(os.path.getatime(filepath))


### PR DESCRIPTION
This randomly triggered alerts depending on whether or not the check ran before the backup was rotated.  This now correctly checks the current time and the file timestamp on a common (UTC) basis and gives up to [an hour grace period](https://github.com/sanger-pathogens/citation_reporter/blob/2a8f7c70adca103761bb6079a2a07fc19e4ccee1/sanger_deployment/checks/check_citation_reporter_web_backups.py#L27).