### PR TITLE
Fix monitoring of monitoring logs

### DIFF
--- a/sanger_deployment/backup.logrotate.conf
+++ b/sanger_deployment/backup.logrotate.conf
@@ -16,6 +16,9 @@ missingok
   dateext
   olddir /var/opt/citation_reporter_prod/backups/monit
   extension .log
+  prerotate
+    echo "Something in case there were no logs today" >> /var/opt/citation_reporter_prod/monit.log
+  endscript
 }
 /var/opt/citation_reporter_prod/backups/publications-latest.yml.tgz {
   rotate 50


### PR DESCRIPTION
The script I use to check backups considers an empty file to be a failure.  Unfortunately there are no failures some days and so the monit logs are empty.  This appends something to the end of the file so that the check passes on good days as well as bad.

I've made the change in production and already checked that it works :)